### PR TITLE
#16. Ensure no empty strings in keywords prompt. Closes #16

### DIFF
--- a/src/Helpers/Prompt.Helpers.test.ts
+++ b/src/Helpers/Prompt.Helpers.test.ts
@@ -1,4 +1,9 @@
-import { getUserCurrentFolder, projectNameValidator, versionValidator } from './Prompt.Helpers';
+import {
+  filterEmptyPromptListItems,
+  getUserCurrentFolder,
+  projectNameValidator,
+  versionValidator
+} from './Prompt.Helpers';
 import * as semver from 'semver';
 
 describe('Getting user cwd', () => {
@@ -31,5 +36,11 @@ describe('semver validation', () => {
 
   it('returns false given an invalid version', () => {
     expect(versionValidator('a.b.c')).toBeFalsy();
+  });
+});
+
+describe('filter empty prompt list items', () => {
+  it('returns a list without any empty string items', () => {
+    expect(filterEmptyPromptListItems(['some item', '', 'some other item'])).toEqual(['some item', 'some other item']);
   });
 });

--- a/src/Helpers/Prompt.Helpers.ts
+++ b/src/Helpers/Prompt.Helpers.ts
@@ -12,3 +12,7 @@ export function projectNameValidator(name: string): boolean {
 export function versionValidator(version: string): boolean {
   return semverValid(version) !== null;
 }
+
+export function filterEmptyPromptListItems(val: string[]): string[] {
+  return val.filter(i => i.length > 0);
+}

--- a/src/Prompts/ProjectKeywords.Prompt.ts
+++ b/src/Prompts/ProjectKeywords.Prompt.ts
@@ -1,10 +1,13 @@
 import { PromptObject } from 'prompts';
+import { filterEmptyPromptListItems } from '../Helpers';
 
 export const projectKeywordsPrompt: PromptObject = {
   type: 'list',
   name: 'projectKeywords',
   separator: ',',
-  message: 'Enter project keywords (separated by comma):'
+  initial: '',
+  message: 'Enter project keywords (separated by comma):',
+  format: filterEmptyPromptListItems
 };
 
 export default projectKeywordsPrompt;


### PR DESCRIPTION
UCreate filterEmptyPromptListItems prompt helper. Update project keywords prompt to format using the filterEmptyPromptListItems prompt helper.